### PR TITLE
Add zOS conventional right padding to main content pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zer0-os/zos-feed",
-  "version": "1.29.2",
+  "version": "1.30.0",
   "description": "feed app for zos",
   "main": "dist/index.js",
   "scripts": {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,6 +5,8 @@
   display: flex;
   justify-content: center;
   overflow: auto;
+  /* zOS app content convention */
+  padding-right: var(--layout-app-content-right-padding);
 }
 
 .feed-filters__section-header {


### PR DESCRIPTION
https://www.notion.so/zerotech/9a4ed77a5ea14501a3e6ef7a33f5a546?v=21e3add7413040bfb3eaf77e8c689cec&p=a2badc2a9c354fee800342544f121f8c&pm=s

This adds right padding to the main feed pane as is now the convention for adhering to the zOS layout in zer0-os/zOS#290.
