### PR TITLE
Hide expected console error during test

### DIFF
--- a/src/store/saga.test.ts
+++ b/src/store/saga.test.ts
@@ -212,6 +212,8 @@ describe('feed saga', () => {
     });
 
     it('should set status to failed on case of an error', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => { });
+
       const error = new Error('error');
 
       await expectSaga(load, { payload: { route: '', provider: {} } })
@@ -225,6 +227,8 @@ describe('feed saga', () => {
           payload: AsyncActionStatus.Failed,
         })
         .run();
+
+      jest.restoreAllMocks();
     });
   });
 


### PR DESCRIPTION
This hides an expected console error message from the test output.

Before, yuck:
![before](https://user-images.githubusercontent.com/43770/212191154-46966fd9-90b1-4f44-9407-9db548eeba8a.png)


After, yay!!:
![after](https://user-images.githubusercontent.com/43770/212191169-6d453e01-b537-4661-b0d6-f4fcb71e387a.png)
